### PR TITLE
Add a CMakeLists.txt to the root of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.16)
+project(inireader)
+
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
+
+target_include_directories(${PROJECT_NAME} INTERFACE include)
+
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  message(STATUS "Loading test/CMakeLists.txt")
+  add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ add_subdirectory(inireader)
 
 add_executable(${PROJECT_NAME} main.cpp)
 
-# Include the inireader headers via the cmake INTERFACE library.
+# Include the inireader headers via the cmake INTERFACE library API.
 target_link_libraries(${PROJECT_NAME} PRIVATE inireader::inireader)
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For examples look at the [wiki](https://github.com/X-rays5/inireader/wiki)
 ```cpp
 #include <iostream>
 #include <fstream>
-#include "inireader.hpp"
+#include <inireader/inireader.hpp>
 
 /*
 config.ini:
@@ -40,4 +40,19 @@ int main() {
 
     return EXIT_SUCCESS;
 }
+```
+# CMake usage
+```cmake
+cmake_minimum_required(VERSION 3.24)
+project(example)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_subdirectory(inireader)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+# Include the inireader headers via a cmake INTERFACE library.
+target_link_libraries(${PROJECT_NAME} PRIVATE inireader::inireader)
+
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ add_subdirectory(inireader)
 
 add_executable(${PROJECT_NAME} main.cpp)
 
-# Include the inireader headers via a cmake INTERFACE library.
+# Include the inireader headers via the cmake INTERFACE library.
 target_link_libraries(${PROJECT_NAME} PRIVATE inireader::inireader)
 
 ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,9 +5,10 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(vendor/googletest)
 enable_testing()
-include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
-add_executable(test_inireader test.cpp)
+add_executable(${PROJECT_NAME} test.cpp)
 
-target_link_libraries(test_inireader gtest gtest_main)
-add_test(test_inireader test_inireader)
+target_include_directories(${PROJECT_NAME} PRIVATE ${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} gtest gtest_main)
+
+add_test(inireader ${PROJECT_NAME})


### PR DESCRIPTION
This wil make it possible to include the library as a subdirectory in cmake.

 So you can include the project with 2 lines.
```cmake
add_subdirectory(inireader)
# Include the inireader headers via a cmake INTERFACE library.
target_link_libraries(${PROJECT_NAME} PRIVATE inireader::inireader)
```