### PR TITLE
Preserve comments when parsing and rewriting INI files

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -165,6 +165,65 @@ TEST(Conversion, UTF8) {
   #endif
 }
 
+TEST(PreserveComments, CheckComments) {
+  constexpr const char* testfile = "default section value = test value ; section less\n"
+                                   "\n"
+                                   "; Comment before section\n"
+                                   "[comment_val]\n"
+                                   "val1 = \"##hello\"\n"
+                                   "val2## = world\n"
+                                   "val3 = he##llo\n"
+                                   "\n"
+                                   "; Comment after values\n"
+                                   "[Section 1]\n"
+                                   "; comment\n"
+                                   "# comment2\n"
+                                   "test_line_break = test1\r"
+                                   "Option 1 = value 1                     ; option 'Option 1' has value 'value 1'\n"
+                                   "Option 2 =  value 2                     # option 'Option 2' has value 'value 2'\n"
+                                   "oPtion 1    =  value 2\\ \\ \\          ; option 'oPtion 1' has value ' value 2   ', 'oPtion 1' and 'Option 1' are different\n"
+                                   "Option 3= value 3 = not value 2\n"
+                                   "option 3  =value 3 = not value 2 = not value 1\\\n"
+                                   "\n"
+                                   "[Numbers]\n"
+                                   "num = -1285\n"
+                                   "num_bin = 0b01101001\n"
+                                   "num_hex = 0x12ae\n"
+                                   "num_oct = 01754\n"
+                                   "num_uint64 = 1122334400000000\n"
+                                   "\n"
+                                   "float1 = -124.45667356\n"
+                                   "float2 = 4.123456545\n"
+                                   "float3 = 412.3456545\n"
+                                   "float4 = -1.1245864\n"
+                                   "\n"
+                                   "[Other]\n"
+                                   "bool1 = 1\n"
+                                   "bool2 = on\n"
+                                   "bool3=off";
+  std::ofstream writer("test_comments.ini");
+  writer << testfile;
+  writer.close();
+
+  ini::Parser ini_file;
+  ini_file.Parse(testfile, false);
+
+  std::ofstream writer_out("test_comments_out.ini");
+  writer_out << ini_file.Stringify();
+  writer_out.close();
+
+  std::ifstream original("test_comments.ini");
+  std::ifstream rewritten("test_comments_out.ini");
+
+  std::string original_content((std::istreambuf_iterator<char>(original)), std::istreambuf_iterator<char>());
+  std::string rewritten_content((std::istreambuf_iterator<char>(rewritten)), std::istreambuf_iterator<char>());
+
+  EXPECT_EQ(original_content, rewritten_content);
+
+  std::filesystem::remove("test_comments.ini");
+  std::filesystem::remove("test_comments_out.ini");
+}
+
 int main(int argc, char** argv) {
   constexpr const char* testfile = "default section value = test value ; section less\n"
                                    "\n"


### PR DESCRIPTION
Preserve comments when parsing and rewriting INI files.

* Add a new member variable `std::string comment_` to `IniValue` and `IniSection` to store comments.
* Modify the `RemoveComment` function to store comments in the new member variables instead of removing them.
* Update the `Stringify` function to include comments from the new member variables in their original positions.
* Ensure that comments before sections are stored in the appropriate section's comment member variable.
* Ensure that comments after values are stored in the appropriate value's comment member variable.
* Add a unit test to check if comments are preserved when parsing and rewriting files.
* Create a test INI file with various types of comments.
* Parse the test INI file using the `ini::Parser` class.
* Rewrite the parsed data back to a new INI file.
* Compare the original test INI file with the rewritten INI file to ensure that all comments are preserved in their original positions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/X-rays5/inireader?shareId=d9d8fdb4-7689-4f37-a2be-e50f3da45df3).